### PR TITLE
Resolve Concurrent Logging Issues

### DIFF
--- a/xml_utils/xml2csv.py
+++ b/xml_utils/xml2csv.py
@@ -1,5 +1,6 @@
 import codecs
 import logging
+import multiprocessing
 import re
 import xml.etree.ElementTree as ET  # noqa
 
@@ -18,10 +19,7 @@ class XML2CSV:
         self.output = None
 
         # Create logger object.
-        self.logger = logging.getLogger('evtx_ripper')
-        self.logger.setLevel(logging.DEBUG)
-        fh = logging.FileHandler('evtx_ripper.log')
-        self.logger.addHandler(fh)
+        self.logger = multiprocessing.get_logger()
 
         # Open the xml file for iteration.
         self.context = ET.iterparse(input_file, events=("start", "end"))

--- a/xml_utils/xml2sql.py
+++ b/xml_utils/xml2sql.py
@@ -1,4 +1,5 @@
 import logging
+import multiprocessing
 import re
 import xml.etree.ElementTree as ElemTree
 from sqlite3 import Error
@@ -20,10 +21,8 @@ class XML2SQL:
         self.num_insert = 0
 
         # Create logger object.
-        self.logger = logging.getLogger('evtx_ripper')
-        self.logger.setLevel(logging.DEBUG)
-        fh = logging.FileHandler('evtx_ripper.log')
-        self.logger.addHandler(fh)
+        self.logger = multiprocessing.get_logger()
+        self.logger.info("I got logz")
 
         self.cursor = None
 


### PR DESCRIPTION
- Refactors extx-ripper module to make use of the get_logger() method of the mulitprocessing library.
- Ammends modules of xml_utils package to utilise the get_logger method of the multiprocessing library.
- Resolves logical error in processor method of evtx-ripper module

See Issue: #2